### PR TITLE
Fix brunch cooking slot reservation to use correct spot_index

### DIFF
--- a/netlify/functions/reserveBrunchCookingSlot.js
+++ b/netlify/functions/reserveBrunchCookingSlot.js
@@ -95,7 +95,7 @@ exports.handler = async (event, context) => {
         .from('brunch_cooking_slots')
         .select('*')
         .eq('time_slot', spotTime)
-        .eq('spot_index', (positionIndex + 1).toString())
+        .eq('spot_index', spotIndex)
         .not('name', 'is', null);
 
       if (checkError) {
@@ -126,7 +126,7 @@ exports.handler = async (event, context) => {
         .from('brunch_cooking_slots')
         .update({ name, email })
         .eq('time_slot', spotTime)
-        .eq('spot_index', (positionIndex + 1).toString());
+        .eq('spot_index', spotIndex);
 
       if (updateError) {
         console.error('Error reserving cooking slot:', updateError);

--- a/src/components/BrunchCookingForm.jsx
+++ b/src/components/BrunchCookingForm.jsx
@@ -66,12 +66,11 @@ const BrunchCookingForm = ({ slots: initialSlots, onSpotReserved }) => {
 
     try {
       // Get the index of the selected slot in the array
-      const spotIndex = cookingSlots.findIndex(slot => slot.time === selectedSlot.time);
+      const spotIndex = selectedSlot.positions[selectedPosition].spot_index;
       
-      if (spotIndex === -1) {
+      if (spotIndex === undefined) {
         throw new Error("Créneau non trouvé");
       }
-
 
       // Prepare data for submission
       const dataToSubmit = {

--- a/src/pages/WeNeedYouPage.jsx
+++ b/src/pages/WeNeedYouPage.jsx
@@ -34,7 +34,7 @@ const WeNeedYouPage = () => {
       if (!grouped[row.time_slot]) {
         grouped[row.time_slot] = { time: row.time_slot, positions: [] };
       }
-      grouped[row.time_slot].positions[row.spot_index] = { name: row.name || "" };
+      grouped[row.time_slot].positions[row.spot_index] = { name: row.name || "", spot_index: row.spot_index };
     });
     return Object.values(grouped);
   }


### PR DESCRIPTION
- Pass the actual spot_index from the frontend to the backend when reserving a slot.
- Update groupCookingSlots to include spot_index in each position.
- Update backend to use spotIndex directly for availability check and update, instead of calculating from positionIndex.
- Resolves false 'slot already reserved' errors and ensures correct slot is updated.