### PR TITLE
feat: add Surprise page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ const RSVPPage = lazy(() => import('./pages/RSVPPage'));
 const WeNeedYouPage = lazy(() => import('./pages/WeNeedYouPage'));
 const WeddingListPage = lazy(() => import('./pages/WeddingListPage'));
 const ChildrenPage = lazy(() => import('./pages/ChildrenPage'));
+const SurprisePage = lazy(() => import('./pages/SurprisePage'));
 
 // Loading component for Suspense fallback
 const LoadingSpinner = () => (
@@ -38,6 +39,7 @@ const App = () => {
                 <Route path="/volontaire" element={<WeNeedYouPage />} />
                 <Route path="/liste-de-mariage" element={<WeddingListPage />} />
                 <Route path="/enfants" element={<ChildrenPage />} />
+                <Route path="/surprise" element={<SurprisePage />} />
               </Routes>
             </Suspense>
           </main>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -22,6 +22,7 @@ const Footer = () => {
               <Link to="/hebergements" className="text-gray-400 hover:text-white transition">Hébergements</Link>
               <Link to="/transport" className="text-gray-400 hover:text-white transition">Transports</Link>
               <Link to="/volontaire" className="text-gray-400 hover:text-white transition">Volontaires</Link>
+              <Link to="/surprise" className="text-gray-400 hover:text-white transition">Surprise</Link>
               <Link to="/liste-de-mariage" className="text-gray-400 hover:text-white transition">Liste de mariage</Link>
               <Link to="/enfants" className="text-gray-400 hover:text-white transition">Enfants</Link>
               <Link to="/confirmez-votre-venue" className="text-gray-400 hover:text-white transition">Confirmez votre venue</Link>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -24,6 +24,7 @@ const Header = () => {
         <Link to="/hebergements" className="hover:underline">Hébergements</Link>
         <Link to="/transport" className="hover:underline">Transports</Link>
         <Link to="/volontaire" className="hover:underline">Volontaires</Link>
+        <Link to="/surprise" className="hover:underline">Surprise</Link>
         <Link to="/liste-de-mariage" className="hover:underline">Liste de mariage</Link>
         <Link to="/enfants" className="hover:underline">Enfants</Link>
         <Link to="/confirmez-votre-venue" className="bg-white text-black px-4 py-2 uppercase text-sm font-semibold hover:bg-gray-100">
@@ -100,6 +101,13 @@ const Header = () => {
               onClick={closeMenu}
             >
               Volontaires
+            </Link>
+            <Link
+              to="/surprise"
+              className="py-2 hover:underline"
+              onClick={closeMenu}
+            >
+              Surprise
             </Link>
             <Link
               to="/liste-de-mariage"

--- a/src/pages/SurprisePage.jsx
+++ b/src/pages/SurprisePage.jsx
@@ -1,0 +1,28 @@
+import ProposalForm from '../components/ProposalForm';
+
+const SurprisePage = () => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <section className="py-32 px-6 bg-white">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-4xl text-center mb-8 text-gray-800">Vous voulez nous faire des surprises ?</h1>
+
+          <p className="text-center text-lg mb-12 text-gray-700 leading-relaxed">
+            Vous pouvez contacter Aude, maitresse de cérémonie, via le formulaire suivant.<br />
+            Elle reviendra vers vous après avoir échangé avec Hubert et Romain, également maîtres de cérémonie,
+            pour organiser au mieux votre surprise en fonction du déroulé du week-end.<br />
+            Merci d'avance !
+          </p>
+
+          <div className="flex justify-center mb-8">
+            <div className="w-24 h-px bg-gray-400"></div>
+          </div>
+
+          <ProposalForm />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SurprisePage;

--- a/src/pages/WeNeedYouPage.jsx
+++ b/src/pages/WeNeedYouPage.jsx
@@ -1,5 +1,4 @@
 import { useSupabaseData } from '../hooks/useSupabaseData';
-import ProposalForm from '../components/ProposalForm';
 import BrunchCookingForm from '../components/BrunchCookingForm';
 import VolunteerSlotForm from '../components/VolunteerSlotForm';
 
@@ -271,23 +270,6 @@ const WeNeedYouPage = () => {
         </div>
       </section>
 
-      {/* Proposal Section */}
-      <section className="py-20 px-6 bg-white">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-4xl text-center mb-8 text-gray-800">Vous voulez nous faire des surprises ?</h2>
-          
-          <p className="text-center text-lg mb-12 max-w-3xl mx-auto text-gray-700 leading-relaxed">
-            Vous pouvez contacter Aude, maitresse de cérémonie, via le formulaire suivant. <br />Elle reviendra vers vous après avoir échangé avec Hubert et Romain, également maîtres de cérémonie, pour organiser au mieux votre surprise en fonction du déroulé du week-end. <br />Merci d’avance !
-          </p>
-          
-          <div className="flex justify-center">
-            <div className="w-24 h-px bg-gray-400 my-8"></div>
-          </div>
-          
-          {/* Proposal Form Component */}
-          <ProposalForm />
-        </div>
-      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Nouvelle page `/surprise` avec le formulaire de contact pour les surprises de mariage (coordonnées d'Aude, Hubert et Romain)
- Lien "Surprise" ajouté dans la navigation desktop, mobile et le footer
- Suppression de la section proposition dans la page Volontaires (déplacée vers la page dédiée)

## Test plan

- [ ] Vérifier que `/surprise` affiche correctement la page avec le texte et le formulaire
- [ ] Vérifier que le lien "Surprise" apparaît dans la nav desktop et mobile
- [ ] Vérifier que le formulaire soumet bien (nom, email, proposition)
- [ ] Vérifier que la page Volontaires n'a plus la section surprise

🤖 Generated with [Claude Code](https://claude.com/claude-code)