### PR TITLE
feat: add Surprise page

### DIFF
--- a/src/pages/SurprisePage.jsx
+++ b/src/pages/SurprisePage.jsx
@@ -3,10 +3,18 @@ import ProposalForm from '../components/ProposalForm';
 const SurprisePage = () => {
   return (
     <div className="flex flex-col min-h-screen">
-      <section className="py-32 px-6 bg-white">
-        <div className="max-w-3xl mx-auto">
-          <h1 className="text-4xl text-center mb-8 text-gray-800">Vous voulez nous faire des surprises ?</h1>
+      {/* Hero Section */}
+      <div className="relative h-[75vh] bg-cover bg-center" style={{ backgroundImage: "url('/gallery/baniere_participez.jpg')" }}>
+        <div className="absolute inset-0 bg-black bg-opacity-50"></div>
+        <div className="absolute inset-0 flex flex-col justify-center items-center text-white text-center px-4">
+          <h1 className="text-5xl md:text-7xl font-light mb-6">Surprise !</h1>
+          <p className="text-xl max-w-2xl">Vous voulez nous faire des surprises ?</p>
+        </div>
+      </div>
 
+      {/* Form Section */}
+      <section className="py-20 px-6 bg-white">
+        <div className="max-w-3xl mx-auto">
           <p className="text-center text-lg mb-12 text-gray-700 leading-relaxed">
             Vous pouvez contacter Aude, maitresse de cérémonie, via le formulaire suivant.<br />
             Elle reviendra vers vous après avoir échangé avec Hubert et Romain, également maîtres de cérémonie,


### PR DESCRIPTION
## Summary

- Nouvelle page `/surprise` avec hero banner (même style que les autres pages)
- Formulaire de contact pour les surprises de mariage (Aude, Hubert et Romain)
- Lien "Surprise" ajouté dans la nav desktop, mobile et le footer
- Suppression de la section surprise de la page Volontaires

## Test plan

- [x] Vérifier que `/surprise` affiche le hero banner et le formulaire
- [ ] Vérifier que le lien "Surprise" apparaît dans la nav desktop et mobile
- [ ] Vérifier que le formulaire soumet correctement (nom, email, proposition)
- [ ] Vérifier que la page Volontaires n'a plus la section surprise

🤖 Generated with [Claude Code](https://claude.com/claude-code)