### PR TITLE
fix: use baniere_surprise.jpg for Surprise page hero

### DIFF
--- a/src/pages/SurprisePage.jsx
+++ b/src/pages/SurprisePage.jsx
@@ -4,7 +4,7 @@ const SurprisePage = () => {
   return (
     <div className="flex flex-col min-h-screen">
       {/* Hero Section */}
-      <div className="relative h-[75vh] bg-cover bg-center" style={{ backgroundImage: "url('/gallery/baniere_participez.jpg')" }}>
+      <div className="relative h-[75vh] bg-cover bg-center" style={{ backgroundImage: "url('/gallery/baniere_surprise.jpg')" }}>
         <div className="absolute inset-0 bg-black bg-opacity-50"></div>
         <div className="absolute inset-0 flex flex-col justify-center items-center text-white text-center px-4">
           <h1 className="text-5xl md:text-7xl font-light mb-6">Surprise !</h1>


### PR DESCRIPTION
## Summary

- Remplacement de la bannière de la page Surprise par `baniere_surprise.jpg`
- Ajout de l'image `public/gallery/baniere_surprise.jpg` au repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)