### PR TITLE
fix: add missing assets.js to fix broken production build

### DIFF
--- a/src/utils/assets.js
+++ b/src/utils/assets.js
@@ -1,0 +1,5 @@
+const BASE = import.meta.env.VITE_ASSETS_BASE_URL || '';
+
+export function assetUrl(path) {
+  return BASE ? `${BASE}${path}` : path;
+}


### PR DESCRIPTION
## Résumé

Correctif urgent — le build de production est cassé depuis que `src/utils/assets.js` a été référencé dans `WeddingListPage.jsx` mais jamais commité sur `main`.

**Erreur :**
```
Could not resolve "../utils/assets" from "src/pages/WeddingListPage.jsx"
```

**Fix :** ajout du fichier `src/utils/assets.js` manquant. Ce fichier expose `assetUrl(path)` qui préfixe les URLs d'assets avec `VITE_ASSETS_BASE_URL` (ou chemin relatif si la variable est absente).

## Plan de test

- [ ] Build Netlify passe (plus d'erreur `Could not resolve`)
- [ ] `/liste-de-mariage` affiche les images correctement en preview
- [ ] Aucune régression sur les autres pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)