### PR TITLE
fix: use assetUrl() for accommodation images from Supabase DB

### DIFF
--- a/src/pages/AccommodationPage.jsx
+++ b/src/pages/AccommodationPage.jsx
@@ -20,7 +20,7 @@ const AccommodationPage = () => {
       {/* Image */}
       <div className="h-48 overflow-hidden relative">
         <OptimizedImage
-          src={accommodation.image || 'https://images.unsplash.com/photo-1566073771259-6a8506099945?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8aG90ZWx8ZW58MHx8MHx8fDA%3D&auto=format&fit=crop&w=500&q=60'}
+          src={accommodation.image ? assetUrl(accommodation.image) : 'https://images.unsplash.com/photo-1566073771259-6a8506099945?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8aG90ZWx8ZW58MHx8MHx8fDA%3D&auto=format&fit=crop&w=500&q=60'}
           alt={accommodation.name}
           className={`w-full h-full object-cover ${accommodation.is_reserved ? 'grayscale' : ''}`}
         />


### PR DESCRIPTION
## Résumé

- `AccommodationPage.jsx` passait `accommodation.image` directement à `OptimizedImage` sans `assetUrl()`
- La DB Supabase stocke des chemins nus (`/gallery/gites/bienvenue-a-dalbepierre.jpg`) pour les 18 hébergements
- Depuis la migration Supabase Storage (PR #60), ces fichiers ne sont plus dans le repo git → 404 en prod
- Fix : `assetUrl(accommodation.image)` (fallback Unsplash si `image` est null)

## Plan de test

- [ ] Dev local : `/hebergements` → les 18 cartes gîtes chargent les photos depuis Supabase CDN
- [ ] Vérifier que les gîtes sans image (`image = null`) affichent bien le fallback Unsplash
- [ ] Deploy preview Netlify (nécessite `VITE_ASSETS_BASE_URL` dans les env vars Netlify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)